### PR TITLE
chore: upgrade undici to fix the dependabot alert 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "jszip": "3.10.1",
         "ts-node": "10.9.1",
         "typescript": "5.2.2",
-        "undici": "5.28.4",
+        "undici": "5.28.5",
         "zod": "3.22.4"
       }
     },
@@ -9353,9 +9353,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "version": "5.28.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
+      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
       "dev": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jszip": "3.10.1",
     "ts-node": "10.9.1",
     "typescript": "5.2.2",
-    "undici": "5.28.4",
+    "undici": "5.28.5",
     "zod": "3.22.4"
   },
   "prettier": {


### PR DESCRIPTION
[Use of Insufficiently Random Values in undici](https://github.com/Stedi-Demos/plugin-http/security/dependabot/11)